### PR TITLE
Add permissions for reading agent pools

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -127,6 +127,7 @@ resource "azurerm_role_definition" "expel_aks_role" {
     actions = [
       "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action",
       "Microsoft.ContainerService/managedClusters/read",
+      "Microsoft.ContainerService/managedClusters/agentPools/read",
       "Microsoft.ContainerService/managedClusters/privateEndpointConnections/read",
       "Microsoft.ContainerService/managedClusters/diagnosticsState/read"
     ]

--- a/static/ExpelAKSRole.json
+++ b/static/ExpelAKSRole.json
@@ -14,6 +14,7 @@
                 [
                     "Microsoft.ContainerService/managedClusters/listClusterUserCredential/action",
                     "Microsoft.ContainerService/managedClusters/read",
+                    "Microsoft.ContainerService/managedClusters/agentPools/read",
                     "Microsoft.ContainerService/managedClusters/privateEndpointConnections/read",
                     "Microsoft.ContainerService/managedClusters/diagnosticsState/read"
                 ],


### PR DESCRIPTION
This allows Expel to inventory nodes in AKS clusters